### PR TITLE
fix(deps): update core dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-Django==4.2.22
-pymongo==4.6.3
-python-dateutil==2.8.1
-pytz==2020.1
-six==1.15.0
-sqlparse==0.5.0
+Django==6.0.1
+pymongo==4.16.0
+python-dateutil==2.9.0.post0
+pytz==2025.2
+six==1.17.0
+sqlparse==0.5.5


### PR DESCRIPTION
## Summary

This commit updates core dependencies to resolve a critical import error caused by `six.moves`, which prevented Django from initializing properly with older dependency versions.

Core dependencies are now updated to their latest compatible versions:

- Django: 4.2.22 → 6.0.1
- pymongo: 4.6.3 → 4.16.0
- python-dateutil: 2.8.1 → 2.9.0.post0
- pytz: 2020.1 → 2025.2
- six: 1.15.0 → 1.17.0
- sqlparse: 0.5.0 → 0.5.5

## Notes

- The `six.moves` import error is resolved by updating `six` and `python-dateutil`.
- All changes were verified in a clean virtual environment, and the Django application now starts successfully.