### PR TITLE
Update scorecard workflow dependencies to latest versions

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -35,12 +35,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
+        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # pin@v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -65,7 +65,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # pin@v6.0.0
         with:
           name: SARIF file
           path: results.sarif
@@ -74,6 +74,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@f3a6ee42055dd5f618fb31d987aae7b94518f043 # pin@v4.32.2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Update all GitHub Actions in the scorecard workflow to their latest versions with pinned SHA hashes for supply-chain security.

Updated actions:
- actions/checkout: v4.2.2 → v6.0.2
- ossf/scorecard-action: v2.4.1 → v2.4.3 (bumps Scorecard to v5.3.0)
- actions/upload-artifact: v4.6.1 → v6.0.0
- github/codeql-action/upload-sarif: v4 (unpinned) → v4.32.2 (pinned)

SHA hashes verified via git ls-remote:
  de0fac2e4500dabe0009e67214ff5f5447ce83dd  refs/tags/v6.0.2 99c09fe975337306107572b4fdf4db224cf8e2f2  refs/tags/v2.4.3 b7c566a772e6b6bfb58ed0dc250532a479d7789f  refs/tags/v6.0.0 f3a6ee42055dd5f618fb31d987aae7b94518f043  refs/tags/v4.32.2

Pinning the previously unpinned codeql-action/upload-sarif also improves the OpenSSF Scorecard Pinned-Dependencies check.