### PR TITLE
Add OpenSSF Best Practices badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # apis-service_center
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/hyphae/apis-service_center/badge)](https://scorecard.dev/viewer/?uri=github.com/hyphae/apis-service_center)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11905/badge)](https://www.bestpractices.dev/projects/11905)
 
 ## Introduction
 


### PR DESCRIPTION
Add the OpenSSF Best Practices badge linking to the project's entry at https://www.bestpractices.dev/projects/11905

The OpenSSF Scorecard CII-Best-Practices check currently scores 0/10: "no effort to earn an OpenSSF best practices badge detected"

Registering the project on bestpractices.dev and adding the badge allows the Scorecard to detect the project's participation. The current in-progress status (15%) will raise the score from 0 to 2.

Reference:
https://github.com/ossf/scorecard/blob/main/docs/checks.md#cii-best-practices