### PR TITLE
Add CodeQL workflow for SAST to improve OpenSSF Scorecard

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+# CodeQL static analysis for SAST (Static Application Security Testing).
+
+name: "CodeQL"
+
+on:
+  # Scan every commit pushed to main.
+  push:
+    branches: [ "main" ]
+  # Scan pull requests before merging to catch vulnerabilities early.
+  pull_request:
+    # The branches below must be a subset of the branches above.
+    branches: [ "main" ]
+  # Weekly scan every Monday at 03:25 UTC.
+  schedule:
+    - cron: '25 3 * * 1'
+
+# Declare default permissions as read only (principle of least privilege).
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/analyze to upload results
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'python', 'javascript' ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@f3a6ee42055dd5f618fb31d987aae7b94518f043 # pin@v4.32.2
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@f3a6ee42055dd5f618fb31d987aae7b94518f043 # pin@v4.32.2
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Add GitHub Actions workflow to run CodeQL static analysis on every push to main, on pull requests, and on a weekly schedule (Monday 03:25 UTC).

This addresses the OpenSSF Scorecard SAST check, which currently scores 0/10 because "0 commits out of 10 are checked with a SAST tool." CodeQL is GitHub's native SAST engine and is explicitly recognized by the Scorecard.

Languages analyzed: Python, JavaScript (both interpreted — no autobuild step needed).

Actions used (all pinned to SHA for supply-chain security):
- actions/checkout v6.0.2
- github/codeql-action/init v4.32.2
- github/codeql-action/analyze v4.32.2

Using CodeQL Action v4 (not v3, which is deprecated December 2026): https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/

SHA hashes verified via git ls-remote:
  git ls-remote https://github.com/actions/checkout.git refs/tags/v6.0.2
  de0fac2e4500dabe0009e67214ff5f5447ce83dd  refs/tags/v6.0.2

  git ls-remote https://github.com/github/codeql-action.git refs/tags/v4.32.2
  f3a6ee42055dd5f618fb31d987aae7b94518f043  refs/tags/v4.32.2

Cron schedule uses a non-round minute (25) to avoid GitHub Actions peak load at :00 as recommended by GitHub:
https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule

References:
- OpenSSF Scorecard: https://scorecard.dev/viewer/?uri=github.com/hyphae/apis-service_center
- CodeQL docs: https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql