### PR TITLE
Update Python environment for Python 3.13 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Django==6.0.1
-pymongo==4.16.0
+Django
+pymongo
 python-dateutil==2.9.0.post0
 pytz==2025.2
 six==1.17.0

--- a/venv.sh
+++ b/venv.sh
@@ -9,5 +9,5 @@ fi
 
 $PYTHON -m venv venv
 . venv/bin/activate
-pip install --upgrade pip
-pip install -r requirements.txt
+pip install --upgrade pip setuptools wheel
+pip install --no-build-isolation -r requirements.txt


### PR DESCRIPTION
This PR updates the service center to be compatible with Python 3.13.
Changes:
- Updated venv.sh to install setuptools and wheel, and use --no-build-isolation flag
- Relaxed Django and pymongo version constraints to allow installation on Python 3.13
The service center now runs successfully on Python 3.13.
Co-authored-by: YATIN JAMWAL <YATIN072007@users.noreply.github.com>