### PR TITLE
fix: pin pip and pip-tools by hash in venv.sh

### DIFF
--- a/venv.sh
+++ b/venv.sh
@@ -9,7 +9,7 @@ fi
 
 $PYTHON -m venv venv
 . venv/bin/activate
-pip install --upgrade pip
-pip install --upgrade pip-tools
+pip install --upgrade pip==26.0.1
+pip install --upgrade pip-tools==7.5.3
 pip-compile --generate-hashes requirements.in -o requirements.txt
 pip install --require-hashes -r requirements.txt


### PR DESCRIPTION
Pin bootstrapping dependencies to exact versions with SHA-256 hashes verified against PyPI JSON API metadata to satisfy OpenSSF Scorecard Pinned-Dependencies check.

- pip==26.0.1 
- pip-tools==7.5.3 