### PR TITLE
fix: correct ossf/scorecard-action pin hash for v2.4.3

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -40,7 +40,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # pin@v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # pin@v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary

- The `ossf/scorecard-action` step was pinned to an incorrect commit hash (`99c09fe`) 
- This caused every Scorecard workflow run since Feb 7 to fail with a `400 Bad Request` "imposter commit" error 
- Updated the pin to the correct commit hash (`4eaacf0543bb3f2c246792bd56e8cdeffafb205a`) for the `v2.4.3` release

## Fix

Replaced the wrong hash in `.github/workflows/scorecard.yml`:

## Command

`git ls-remote https://github.com/ossf/scorecard-action refs/tags/v2.4.3`