### PR TITLE
fix(deps): bump Django from 6.0.2 to 6.0.3 to fix 2 vulnerabilities

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-Django==6.0.2
+Django==6.0.3
 pymongo==4.16.0
 python-dateutil==2.9.0.post0
 pytz==2025.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,9 @@ asgiref==3.11.1 \
     --hash=sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce \
     --hash=sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133
     # via django
-django==6.0.2 \
-    --hash=sha256:3046a53b0e40d4b676c3b774c73411d7184ae2745fe8ce5e45c0f33d3ddb71a7 \
-    --hash=sha256:610dd3b13d15ec3f1e1d257caedd751db8033c5ad8ea0e2d1219a8acf446ecc6
+django==6.0.3 \
+    --hash=sha256:2e5974441491ddb34c3f13d5e7a9f97b07ba03bf70234c0a9c68b79bbb235bc3 \
+    --hash=sha256:90be765ee756af8a6cbd6693e56452404b5ad15294f4d5e40c0a55a0f4870fe1
     # via -r requirements.in
 dnspython==2.8.0 \
     --hash=sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af \
@@ -109,3 +109,7 @@ sqlparse==0.5.5 \
     # via
     #   -r requirements.in
     #   django
+tzdata==2025.3 \
+    --hash=sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1 \
+    --hash=sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7
+    # via django


### PR DESCRIPTION
## Summary

- Bumps Django from 6.0.2 to 6.0.3 to fix 2 security vulnerabilities flagged by Dependabot
- Regenerates `requirements.txt` with updated SHA-256 hashes by running `sh venv.sh`

## Vulnerabilities Fixed

**GHSA-8p8v-wh79-9r56** (High — CVSS 7.5)
- `URLField.to_python()` calls `urllib.parse.urlsplit()` which performs NFKC normalization on Windows that is disproportionately slow for certain Unicode characters, allowing a remote attacker to cause denial of service via large URL inputs
- Fixed in Django 6.0.3

**GHSA-mjgh-79qc-68w3** (Low — CVSS 3.7)
- Race condition in file-system storage and file-based cache backends that could allow attackers to create file system objects with incorrect permissions through concurrent requests in multi-threaded environments
- Fixed in Django 6.0.3

## Changes

- `requirements.in`: `Django==6.0.2` → `Django==6.0.3`
- `requirements.txt`: regenerated with updated hashes via `sh venv.sh`

Closes #54
Closes #55
