### PR TITLE
fix: correct codeql-action pin hash to dereferenced commit SHA

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,11 +36,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f3a6ee42055dd5f618fb31d987aae7b94518f043 # pin@v4.32.2
+        uses: github/codeql-action/init@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # pin@v4.32.2
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f3a6ee42055dd5f618fb31d987aae7b94518f043 # pin@v4.32.2
+        uses: github/codeql-action/analyze@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # pin@v4.32.2
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -74,6 +74,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@f3a6ee42055dd5f618fb31d987aae7b94518f043 # pin@v4.32.2
+        uses: github/codeql-action/upload-sarif@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # pin@v4.32.2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Fixes the scorecard workflow failure caused by an incorrect SHA hash for
`github/codeql-action/upload-sarif`.

## Problem

The previously pinned SHA `f3a6ee42055dd5f618fb31d987aae7b94518f043` is the
**tag object SHA** for `codeql-action@v4.32.2` — not the commit SHA.
The OpenSSF Scorecard webapp performs strict verification and rejects tag
object SHAs, causing the workflow to fail with:


## Fix

Replaced with the **dereferenced commit SHA** `45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2`
which is the actual commit that `v4.32.2` points to, verified via:

git ls-remote https://github.com/github/codeql-action refs/tags/v4.32.2


This fix was confirmed working against the `apis-emulator` sister repo
which runs the same scorecard workflow successfully with this commit SHA.

## Files Changed

- `.github/workflows/scorecard.yml` — fixed `upload-sarif` pin hash
- `.github/workflows/codeql.yml` — fixed `init` and `analyze` pin hashes

## References

- [OpenSSF Scorecard workflow restrictions](https://github.com/ossf/scorecard-action#workflow-restrictions)
- Confirmed working SHA from sister 